### PR TITLE
Add `search` library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "search"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "iai-callgrind",
+ "mancala-lib",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "mancala-player",
     "perft",
     "perft-cli",
+    "search",
 ]
 resolver = "3"

--- a/search/Cargo.toml
+++ b/search/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "search"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mancala-lib = { version = "0.1.0", path = "../mancala-lib" }
+
+[dev-dependencies]
+criterion = "0.7.0"
+iai-callgrind = "0.16.1"

--- a/search/README.md
+++ b/search/README.md
@@ -1,0 +1,9 @@
+# Mancala Search
+
+This library provides tooling for searching the Mancala DAG.
+
+# Scope
+
+- Saving/Loading checkpoints
+- Describing search methods over a DAG
+- Implementing search algorithms for specific types of properties

--- a/search/src/lib.rs
+++ b/search/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
Creates a library to enable:
1. Searching a DAG to compute properties
2. Saving/loading checkpoints for search